### PR TITLE
Add fallback definition for SimplifiedOutput parsing

### DIFF
--- a/question.py
+++ b/question.py
@@ -17,7 +17,7 @@ class QuestionHandler:
             init_logger()
         self.logger = logging.getLogger("HackQ")
 
-        self.simplified_output = config.getboolean("LIVE", "SimplifiedOutput")
+        self.simplified_output = config.getboolean("LIVE", "SimplifiedOutput", fallback=False)
 
         self.fsa = ahocorasick.Automaton()
 


### PR DESCRIPTION
SimplifiedOutput was removed in 53db57b9b1044316975b7b4916e0cb7ec72c72ad, which breaks code execution, this defines a fallback value in question.py so that the code properly assigns a default if it isn't in the configuration data.